### PR TITLE
[fix] a nicer error handling instead of app crash

### DIFF
--- a/ios/Classes/SwiftFlutterAudioRecorderPlugin.swift
+++ b/ios/Classes/SwiftFlutterAudioRecorderPlugin.swift
@@ -64,7 +64,14 @@ public class SwiftFlutterAudioRecorderPlugin: NSObject, FlutterPlugin, AVAudioRe
                 AVNumberOfChannelsKey: 1,
                 AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
             ]
-            
+
+            guard let destinationUrl = URL(string: mPath) else {
+                let errorMessage = "Failed to initialize URL path from string: \(mPath)"
+                print(errorMessage)
+                result(FlutterError(code: "", message: errorMessage, details: error))
+                return
+            }
+
             do {
                 #if swift(>=4.2)
                 try AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playAndRecord, options: AVAudioSession.CategoryOptions.defaultToSpeaker)
@@ -72,7 +79,7 @@ public class SwiftFlutterAudioRecorderPlugin: NSObject, FlutterPlugin, AVAudioRe
                 try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord, with: AVAudioSessionCategoryOptions.defaultToSpeaker)
                 #endif
                 try AVAudioSession.sharedInstance().setActive(true)
-                audioRecorder = try AVAudioRecorder(url: URL(string: mPath)!, settings: settings)
+                audioRecorder = try AVAudioRecorder(url: destinationUrl, settings: settings)
                 audioRecorder.delegate = self
                 audioRecorder.isMeteringEnabled = true
                 audioRecorder.prepareToRecord()


### PR DESCRIPTION
## Main Change
* Now the app won't crash in case the string path represents an invalid URL (probably due to spaces in path).
* The plugin will return a Flutter error instead.

### Tip 💡
Try not to use force unwrap `!` unless you want the app to crash. For example, in `let dic = call.arguments as! [String : Any]` it's still forgiven because this dictionary must exist, unless there's an integration error. Although I personally prefer to use safe unwrap (`if let` / `guard let`) in these cases as well.